### PR TITLE
Refactor: Display email validation errors inline

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <h1>Email using Duck.com Address</h1>
     <form>
         <p>
-            <label for="from">Enter your Duck.com Email Address:</label> <input type="email" name="from" id="from" placeholder="you@duck.com" required>
+            <label for="from">Enter your Duck.com Email Address:</label> <input type="email" name="from" id="from" placeholder="you@duck.com" required> <span id="emailError" class="error-message"></span>
         </p>
         <p>
             <label for="to">Enter Recipient's email address:</label> <input type="email" name="to" id="to" placeholder="email@xyz.com" required>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
 const form = document.querySelector('form');
+const emailError = document.getElementById('emailError');
+const resultDiv = document.getElementById('output');
 
 form.onsubmit = function(e) {
     e.preventDefault();
@@ -6,15 +8,15 @@ form.onsubmit = function(e) {
     const domain = email.split('@')[1];
     
     if (domain !== 'duck.com') {
-        alert('First email should have domain `duck.com`');
+        emailError.textContent = 'First email should have domain `duck.com`';
+        resultDiv.innerHTML = '';
     }
     else {
-        const result = document.getElementById('result');
+        emailError.textContent = '';
         const toEmail = document.getElementById('to').value;
         const convertEmail = email => email.replace('@', '_at_');
         let resultEmail = convertEmail(toEmail);
         resultEmail = resultEmail + "_" + email;
-        const resultDiv = document.getElementById('output');
         resultDiv.innerHTML = `<h2>Result</h2><p id="result" title="Click to Copy" data-clipboard-target="#result"> ${resultEmail} </p>`;
         let clipboard = new ClipboardJS('#result');
     }

--- a/style.css
+++ b/style.css
@@ -33,3 +33,9 @@ input[type="email"] {
 #result {
     font-size: 1.5em;
 }
+
+.error-message {
+    color: red;
+    font-size: 0.9em;
+    margin-left: 5px;
+}


### PR DESCRIPTION
I replaced the JavaScript alert() with an inline error message for non-Duck.com email addresses.

Changes include:
- Added a span element in index.html to hold the error message.
- Updated script.js to display the error message in this span and clear it when the input is valid.
- Added CSS styling for the error message (red color, slightly smaller font).